### PR TITLE
fix: convert tables containing bullet lists to Markdown (#6)

### DIFF
--- a/converter/markdown.go
+++ b/converter/markdown.go
@@ -62,6 +62,10 @@ var (
 	cellParagraphOpenPattern = regexp.MustCompile(`<p[^>]*>`)
 	cellBreakPattern         = regexp.MustCompile(`<br\s*/?>`)
 	whitespaceRunPattern     = regexp.MustCompile(`\s+`)
+
+	// Patterns for promoting a table's header row (see promoteTableHeaderRows).
+	tableBlockPattern = regexp.MustCompile(`(?is)<table>.*?</table>`)
+	tableRowPattern   = regexp.MustCompile(`(?is)<tr>.*?</tr>`)
 )
 
 // CheckPandoc verifies that pandoc is available (embedded or in PATH).
@@ -288,7 +292,8 @@ func preProcessHTML(html string) string {
 	html = regexp.MustCompile(`<thead[^>]*>`).ReplaceAllString(html, "<thead>")
 	html = regexp.MustCompile(`<tbody[^>]*>`).ReplaceAllString(html, "<tbody>")
 	html = regexp.MustCompile(`<tr[^>]*>`).ReplaceAllString(html, "<tr>")
-	html = regexp.MustCompile(`<th[^>]*>`).ReplaceAllString(html, "<th>")
+	// Match <th> and <th ...> but NOT <thead>, which shares the "<th" prefix.
+	html = regexp.MustCompile(`<th(?:\s[^>]*)?>`).ReplaceAllString(html, "<th>")
 	html = regexp.MustCompile(`<td[^>]*>`).ReplaceAllString(html, "<td>")
 
 	// Remove <br> tags inside table cells (pandoc can't handle them and falls back to HTML)
@@ -333,6 +338,10 @@ func preProcessHTML(html string) string {
 		}
 		return "<td>" + inner + "</td>"
 	})
+
+	// Promote header rows so pandoc emits a real Markdown table header instead of
+	// an empty one (Confluence puts <th> cells inside <tbody> with no <thead>).
+	html = promoteTableHeaderRows(html)
 
 	// Remove span tags inside table cells (especially nolink spans)
 	html = regexp.MustCompile(`<span[^>]*class="[^"]*nolink[^"]*"[^>]*>([\s\S]*?)</span>`).ReplaceAllString(html, "$1")
@@ -392,6 +401,26 @@ func flattenCellLists(inner string) string {
 	inner = cellListTagPattern.ReplaceAllString(inner, "")
 	inner = cellListItemTagPattern.ReplaceAllString(inner, "")
 	return inner
+}
+
+// promoteTableHeaderRows wraps a table's first row in <thead> when the table has
+// no explicit header but that first row is built from <th> cells. Confluence
+// exports place header cells inside <tbody> with no <thead>, which makes pandoc
+// synthesize an empty header row and demote the real headers into the table body.
+// Promoting the row yields a proper Markdown table header.
+func promoteTableHeaderRows(html string) string {
+	return tableBlockPattern.ReplaceAllStringFunc(html, func(table string) string {
+		if strings.Contains(table, "<thead>") {
+			return table // already has an explicit header
+		}
+		firstRow := tableRowPattern.FindString(table)
+		if firstRow == "" || !strings.Contains(firstRow, "<th>") {
+			return table // first row is not a header row; leave as-is
+		}
+		// Lift the first row out of the body and into a <thead> after <table>.
+		rest := strings.Replace(table, firstRow, "", 1)
+		return strings.Replace(rest, "<table>", "<table><thead>"+firstRow+"</thead>", 1)
+	})
 }
 
 // cleanListItemText extracts the plain inline text of a single <li> item,

--- a/converter/markdown.go
+++ b/converter/markdown.go
@@ -22,6 +22,14 @@ const (
 	// maxASCIICodePoint is the maximum code point for ASCII characters.
 	// Used when decoding numeric HTML entities to only decode printable ASCII.
 	maxASCIICodePoint = 127
+
+	// cellLineBreakSentinel is a placeholder inserted during pre-processing to
+	// mark line breaks inside a table cell (e.g. between flattened list items).
+	// Pandoc's GFM writer dumps an entire table as raw HTML when a cell contains
+	// block-level content or a hard <br>, so we flatten cell content to a single
+	// inline line and use this sentinel to stand in for the breaks, then restore
+	// real <br> tags in post-processing (after pandoc has produced a pipe table).
+	cellLineBreakSentinel = "@@C2MDBR@@"
 )
 
 // htmlEntityMap maps HTML entities to their decoded characters.
@@ -40,6 +48,21 @@ var htmlEntityMap = map[string]string{
 	"&#38;":  "&",
 	"&nbsp;": " ",
 }
+
+// Compiled patterns used to flatten <ul>/<ol> list markup inside table cells.
+// Pandoc's GFM writer emits an entire table as raw HTML when any cell holds
+// block-level content (a list), so lists are rewritten as inline "• item" /
+// "N. item" segments before conversion. See flattenCellLists.
+var (
+	cellOrderedListPattern   = regexp.MustCompile(`(?is)<ol[^>]*>.*?</ol>`)
+	cellUnorderedListPattern = regexp.MustCompile(`(?is)<ul[^>]*>.*?</ul>`)
+	cellListItemPattern      = regexp.MustCompile(`(?is)<li[^>]*>.*?</li>`)
+	cellListTagPattern       = regexp.MustCompile(`(?is)</?[uo]l[^>]*>`)
+	cellListItemTagPattern   = regexp.MustCompile(`(?is)</?li[^>]*>`)
+	cellParagraphOpenPattern = regexp.MustCompile(`<p[^>]*>`)
+	cellBreakPattern         = regexp.MustCompile(`<br\s*/?>`)
+	whitespaceRunPattern     = regexp.MustCompile(`\s+`)
+)
 
 // CheckPandoc verifies that pandoc is available (embedded or in PATH).
 func CheckPandoc() error {
@@ -278,16 +301,34 @@ func preProcessHTML(html string) string {
 	// Remove <p> tags inside table cells (unwrap content)
 	// First handle simple single-p cells
 	html = regexp.MustCompile(`(<t[dh]>)\s*<p>([^<]*)</p>\s*(</t[dh]>)`).ReplaceAllString(html, "$1$2$3")
-	// Handle multiple <p> tags in cells - convert to text with spaces
+	// Flatten each cell's content to a single inline line so pandoc produces a
+	// Markdown pipe table. Lists become "• item" / "N. item" segments and
+	// paragraphs are unwrapped; the sentinel marks intra-cell line breaks and is
+	// turned back into <br> during post-processing.
 	html = regexp.MustCompile(`(<t[dh]>)([\s\S]*?)(</t[dh]>)`).ReplaceAllStringFunc(html, func(match string) string {
-		// Remove <p> and </p> tags inside cells, replace with space
-		inner := regexp.MustCompile(`<t[dh]>`).ReplaceAllString(match, "")
-		inner = regexp.MustCompile(`</t[dh]>`).ReplaceAllString(inner, "")
-		inner = regexp.MustCompile(`<p[^>]*>`).ReplaceAllString(inner, "")
-		inner = regexp.MustCompile(`</p>`).ReplaceAllString(inner, " ")
+		isHeader := strings.HasPrefix(match, "<th")
+		inner := regexp.MustCompile(`</?t[dh]>`).ReplaceAllString(match, "")
+
+		// Rewrite <ul>/<ol> lists into inline, sentinel-separated item segments.
+		inner = flattenCellLists(inner)
+
+		// Unwrap paragraphs (join with a space) and collapse any stray <br>,
+		// which would otherwise force pandoc's raw-HTML table fallback.
+		inner = cellParagraphOpenPattern.ReplaceAllString(inner, "")
+		inner = strings.ReplaceAll(inner, "</p>", " ")
+		inner = cellBreakPattern.ReplaceAllString(inner, " ")
+
+		// Collapse all real whitespace (including source newlines) to single
+		// spaces so only the intentional sentinels remain as line breaks, then
+		// tidy spaces around the sentinels and trim stray ones at the edges.
+		inner = whitespaceRunPattern.ReplaceAllString(inner, " ")
+		inner = strings.ReplaceAll(inner, " "+cellLineBreakSentinel, cellLineBreakSentinel)
+		inner = strings.ReplaceAll(inner, cellLineBreakSentinel+" ", cellLineBreakSentinel)
 		inner = strings.TrimSpace(inner)
-		// Detect if it was th or td
-		if strings.HasPrefix(match, "<th") {
+		inner = strings.TrimPrefix(inner, cellLineBreakSentinel)
+		inner = strings.TrimSuffix(inner, cellLineBreakSentinel)
+
+		if isHeader {
 			return "<th>" + inner + "</th>"
 		}
 		return "<td>" + inner + "</td>"
@@ -315,6 +356,55 @@ func preProcessHTML(html string) string {
 	}
 
 	return html
+}
+
+// flattenCellLists rewrites <ul>/<ol> lists found inside a single table cell into
+// inline text: each item becomes a "• item" (unordered) or "N. item" (ordered)
+// segment preceded by cellLineBreakSentinel. Pandoc would otherwise emit the whole
+// table as raw HTML because pipe-table cells cannot hold block-level list content.
+//
+// Limitation: nested sub-lists are flattened to a single bullet level (their items
+// are still preserved as text, just without indentation).
+func flattenCellLists(inner string) string {
+	// Ordered lists first so their items get numbers rather than bullets.
+	inner = cellOrderedListPattern.ReplaceAllStringFunc(inner, func(block string) string {
+		n := 0
+		items := cellListItemPattern.ReplaceAllStringFunc(block, func(li string) string {
+			n++
+			return fmt.Sprintf("%s%d. %s", cellLineBreakSentinel, n, cleanListItemText(li))
+		})
+		return cellListTagPattern.ReplaceAllString(items, "")
+	})
+
+	// Unordered lists.
+	inner = cellUnorderedListPattern.ReplaceAllStringFunc(inner, func(block string) string {
+		items := cellListItemPattern.ReplaceAllStringFunc(block, func(li string) string {
+			return cellLineBreakSentinel + "• " + cleanListItemText(li)
+		})
+		return cellListTagPattern.ReplaceAllString(items, "")
+	})
+
+	// Defensive: bullet any <li> not wrapped in a recognized list, then drop any
+	// leftover list container/item tags so none survive into pandoc.
+	inner = cellListItemPattern.ReplaceAllStringFunc(inner, func(li string) string {
+		return cellLineBreakSentinel + "• " + cleanListItemText(li)
+	})
+	inner = cellListTagPattern.ReplaceAllString(inner, "")
+	inner = cellListItemTagPattern.ReplaceAllString(inner, "")
+	return inner
+}
+
+// cleanListItemText extracts the plain inline text of a single <li> item,
+// unwrapping paragraphs and collapsing whitespace to a single line. Inline
+// formatting (e.g. <strong>) is left intact for pandoc to convert.
+func cleanListItemText(li string) string {
+	t := cellListItemTagPattern.ReplaceAllString(li, "")
+	t = cellParagraphOpenPattern.ReplaceAllString(t, "")
+	t = strings.ReplaceAll(t, "</p>", " ")
+	t = cellListTagPattern.ReplaceAllString(t, " ")
+	t = cellBreakPattern.ReplaceAllString(t, " ")
+	t = whitespaceRunPattern.ReplaceAllString(t, " ")
+	return strings.TrimSpace(t)
 }
 
 // postProcessMarkdown cleans up Confluence-specific HTML artifacts from the converted Markdown.
@@ -524,6 +614,13 @@ func postProcessMarkdown(md string) string {
 	for code, emoji := range textEmojis {
 		md = strings.ReplaceAll(md, code, emoji)
 	}
+
+	// Restore intra-cell line breaks. The sentinel was inserted during
+	// pre-processing (see flattenCellLists) so pandoc would keep tables as
+	// Markdown pipe tables; now that conversion is done, turn it into a literal
+	// <br>, which GitHub renders as a line break inside the cell. This runs last
+	// so the earlier <br>-to-newline cleanup does not clobber it.
+	md = strings.ReplaceAll(md, cellLineBreakSentinel, "<br>")
 
 	return md
 }

--- a/converter/markdown_test.go
+++ b/converter/markdown_test.go
@@ -970,6 +970,46 @@ func TestPreProcessHTML_TableCellPlainParagraphsUnchanged(t *testing.T) {
 	}
 }
 
+func TestPreProcessHTML_PromoteHeaderRow(t *testing.T) {
+	// Confluence puts <th> cells in <tbody> with no <thead>; the first row should
+	// be lifted into a <thead> so pandoc emits a real Markdown table header.
+	input := `<table><tbody><tr><th><p>H1</p></th><th><p>H2</p></th></tr>` +
+		`<tr><td><p>a</p></td><td><p>b</p></td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	if !strings.Contains(result, "<thead>") {
+		t.Errorf("Expected first header row to be wrapped in <thead>, got: %s", result)
+	}
+	// The header row must appear inside thead, before tbody.
+	if !strings.Contains(result, "<thead><tr><th>H1</th><th>H2</th></tr></thead>") {
+		t.Errorf("Expected promoted header row, got: %s", result)
+	}
+}
+
+func TestPreProcessHTML_PromoteHeaderRow_NoChangeWhenNoHeaderCells(t *testing.T) {
+	// A table whose first row is data (<td>) must be left untouched.
+	input := `<table><tbody><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	if strings.Contains(result, "<thead>") {
+		t.Errorf("Expected no <thead> for a header-less table, got: %s", result)
+	}
+}
+
+func TestPreProcessHTML_PromoteHeaderRow_KeepsExistingThead(t *testing.T) {
+	// A table that already has a <thead> must not be modified.
+	input := `<table><thead><tr><th>H1</th></tr></thead><tbody><tr><td>a</td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	// Exactly one thead, and no duplicate wrapping.
+	if strings.Count(result, "<thead>") != 1 {
+		t.Errorf("Expected exactly one <thead>, got: %s", result)
+	}
+}
+
 func TestPostProcessMarkdown_CellLineBreakSentinel(t *testing.T) {
 	input := "| left side:" + cellLineBreakSentinel + "• foo" + cellLineBreakSentinel + "• bar | right side |"
 
@@ -1016,6 +1056,20 @@ func TestConvertHTMLToMarkdown_TableWithListCell(t *testing.T) {
 	// The flattened list should render as line-broken bullets inside the cell.
 	if !strings.Contains(md, "left side:<br>• foo<br>• bar") {
 		t.Errorf("Expected line-broken bullet cell, got: %s", md)
+	}
+
+	// The header row should be promoted: the "title" row must be immediately
+	// followed by the Markdown separator (no empty synthesized header above it).
+	lines := strings.Split(md, "\n")
+	headerPromoted := false
+	for i, line := range lines {
+		if strings.Contains(line, "**title 1**") && i+1 < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i+1]), "|-") {
+			headerPromoted = true
+			break
+		}
+	}
+	if !headerPromoted {
+		t.Errorf("Expected header row promoted (followed by separator), got: %s", md)
 	}
 }
 

--- a/converter/markdown_test.go
+++ b/converter/markdown_test.go
@@ -916,6 +916,109 @@ func TestPreProcessHTML_ComplexTable(t *testing.T) {
 	}
 }
 
+func TestPreProcessHTML_TableCellUnorderedList(t *testing.T) {
+	// Regression test for issue #6: a bullet list inside a table cell used to
+	// make pandoc emit the whole table as raw HTML. The list must be flattened
+	// to inline, sentinel-separated "• item" segments so pandoc keeps a table.
+	input := `<table><tbody><tr><th><p>title 1</p></th><th><p>title 2</p></th></tr>` +
+		`<tr><td><p>left side:</p><ul><li><p>foo</p></li><li><p>bar</p></li></ul></td>` +
+		`<td><p>right side</p></td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	// No list markup should survive into pandoc.
+	if strings.Contains(result, "<ul") || strings.Contains(result, "<li") {
+		t.Errorf("Expected list tags to be removed from cell, got: %s", result)
+	}
+	// Items should be flattened to inline bullets, joined by the sentinel.
+	want := "left side:" + cellLineBreakSentinel + "• foo" + cellLineBreakSentinel + "• bar"
+	if !strings.Contains(result, want) {
+		t.Errorf("Expected flattened cell %q, got: %s", want, result)
+	}
+	// Unrelated cell content must be preserved.
+	if !strings.Contains(result, "right side") {
+		t.Errorf("Expected other cell content to be preserved, got: %s", result)
+	}
+}
+
+func TestPreProcessHTML_TableCellOrderedList(t *testing.T) {
+	input := `<table><tbody><tr><td><p>steps:</p><ol><li>one</li><li>two</li><li>three</li></ol></td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	if strings.Contains(result, "<ol") || strings.Contains(result, "<li") {
+		t.Errorf("Expected ordered list tags to be removed, got: %s", result)
+	}
+	want := "steps:" + cellLineBreakSentinel + "1. one" + cellLineBreakSentinel + "2. two" + cellLineBreakSentinel + "3. three"
+	if !strings.Contains(result, want) {
+		t.Errorf("Expected numbered cell %q, got: %s", want, result)
+	}
+}
+
+func TestPreProcessHTML_TableCellPlainParagraphsUnchanged(t *testing.T) {
+	// Cells without lists must keep the existing space-joined behavior and must
+	// not gain any sentinel line breaks.
+	input := `<table><tbody><tr><td><p>alpha</p><p>beta</p></td></tr></tbody></table>`
+
+	result := preProcessHTML(input)
+
+	if strings.Contains(result, cellLineBreakSentinel) {
+		t.Errorf("Expected no sentinel in a list-free cell, got: %s", result)
+	}
+	if !strings.Contains(result, "<td>alpha beta</td>") {
+		t.Errorf("Expected space-joined paragraphs, got: %s", result)
+	}
+}
+
+func TestPostProcessMarkdown_CellLineBreakSentinel(t *testing.T) {
+	input := "| left side:" + cellLineBreakSentinel + "• foo" + cellLineBreakSentinel + "• bar | right side |"
+
+	result := postProcessMarkdown(input)
+
+	if strings.Contains(result, cellLineBreakSentinel) {
+		t.Errorf("Expected sentinel to be replaced, got: %s", result)
+	}
+	if !strings.Contains(result, "left side:<br>• foo<br>• bar") {
+		t.Errorf("Expected sentinel converted to <br>, got: %s", result)
+	}
+}
+
+func TestConvertHTMLToMarkdown_TableWithListCell(t *testing.T) {
+	// End-to-end regression for issue #6: the exact table shape from the report
+	// must convert to a Markdown pipe table, not a raw HTML <table> block.
+	if err := CheckPandoc(); err != nil {
+		t.Skipf("Pandoc not installed, skipping test: %v", err)
+	}
+
+	html := `<html><body><h1>testpage</h1>
+<table class="confluenceTable">
+<tbody>
+<tr><th class="confluenceTh"><p><strong>title 1</strong></p></th><th class="confluenceTh"><p><strong>title 2</strong></p></th></tr>
+<tr><td class="confluenceTd"><p>left side:</p><ul><li><p>foo</p></li><li><p>bar</p></li></ul></td><td class="confluenceTd"><p>right side</p></td></tr>
+</tbody>
+</table>
+</body></html>`
+
+	md, err := ConvertHTMLToMarkdown(html)
+	if err != nil {
+		t.Fatalf("ConvertHTMLToMarkdown failed: %v", err)
+	}
+
+	// Must be a Markdown pipe table, not raw HTML.
+	if strings.Contains(md, "<table") || strings.Contains(md, "<ul") {
+		t.Errorf("Expected a Markdown table (no raw HTML), got: %s", md)
+	}
+	for _, want := range []string{"| **title 1**", "**title 2**", "• foo", "• bar", "right side"} {
+		if !strings.Contains(md, want) {
+			t.Errorf("Expected converted markdown to contain %q, got: %s", want, md)
+		}
+	}
+	// The flattened list should render as line-broken bullets inside the cell.
+	if !strings.Contains(md, "left side:<br>• foo<br>• bar") {
+		t.Errorf("Expected line-broken bullet cell, got: %s", md)
+	}
+}
+
 func TestPostProcessMarkdown_AllEmojis(t *testing.T) {
 	// Test all text emoji shortcodes defined in the textEmojis map
 	tests := []struct {


### PR DESCRIPTION
## Summary

Fixes #6 — Confluence tables whose cells contain a bullet/numbered list were left as **raw HTML** instead of a Markdown table.

**Root cause:** pandoc's GFM writer can only place *inline, single-line* content in pipe-table cells. When a cell holds block-level content (a `<ul>`/`<ol>` list), pandoc can't express it as a pipe table and falls back to emitting the **entire table** as raw HTML. (Hard `<br>` breaks in a cell trigger the same fallback — which is why the existing code already strips them.)

**Fix:** In `converter/markdown.go`, flatten in-cell lists to inline `• item` / `N. item` segments **before** pandoc runs, joined by a `@@C2MDBR@@` sentinel. `postProcessMarkdown` restores the sentinel to a literal `<br>` as its final step, so pandoc emits a clean pipe table and GitHub still renders line-broken bullets inside the cell. Cells without lists keep their existing space-joined behavior (no regression).

### Before
```html
<table>
<tbody>
<tr><th><strong>title 1</strong></th><th><strong>title 2</strong></th></tr>
<tr><td>left side:<ul><li>foo</li><li>bar</li></ul></td><td>right side</td></tr>
</tbody>
</table>
```

### After
```
| **title 1**                  | **title 2** |
|------------------------------|-------------|
| left side:<br>• foo<br>• bar | right side  |
```

## Tests
- New unit tests: unordered list, ordered list numbering, list-free cell (regression guard), sentinel→`<br>`.
- New end-to-end `ConvertHTMLToMarkdown` test on the issue's exact table shape (asserts a pipe table, no `<table>`/`<ul>`).
- Full `go test ./...` passes; `gofmt`/`go vet` clean.
- Verified against the reporter's `testpage.doc`.

## Limitation
Deeply nested sub-lists inside a cell flatten to a single bullet level (items preserved as text, no indentation) — acceptable for typical Confluence tables and noted in a code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)