### PR TITLE
fix: strip residual macro HTML from Markdown output (#5)

### DIFF
--- a/converter/fuzz_test.go
+++ b/converter/fuzz_test.go
@@ -75,6 +75,11 @@ func FuzzPreProcessHTML(f *testing.F) {
 		`<td>literal @@C2MDBR@@ sentinel</td>`,
 		`<table><tbody><tr><td><ul><li><strong>b</strong></li><li><a href="u">l</a></li></ul></td></tr></tbody></table>`,
 
+		// Unhandled macro wrappers (issue #5)
+		`<div class="conf-macro output-block" data-macro-name="change-history"><table><tr><td>1.0</td></tr></table></div>`,
+		`<div class="plugin_attachments_container"><div class="plugin_attachments_table_title">Attachments</div></div>`,
+		`<section><p>section body</p></section>`,
+
 		// Spans (various classes)
 		`<span class="nolink">No link text</span>`,
 		`<span class="status-macro aui-lozenge">STATUS</span>`,
@@ -227,6 +232,17 @@ func FuzzPostProcessMarkdown(f *testing.F) {
 		cellLineBreakSentinel,
 		"text " + cellLineBreakSentinel + " more",
 		strings.Repeat(cellLineBreakSentinel, 100),
+
+		// Residual macro wrapper HTML (issue #5)
+		`<div class="conf-macro output-block">Inner</div>`,
+		"<div class=\"a\">\n\n<div class=\"b\">\n\nnested\n\n</div>\n\n</div>",
+		"<section><article>body</article></section>",
+		"<figure><figcaption>cap</figcaption></figure>",
+		"```\n<div class=\"in-code\">sample</div>\n```",
+		"<div>only open",
+		"</div> only close",
+		"<details><summary>keep</summary><div>drop wrapper</div></details>",
+		strings.Repeat(`<div class="x">`, 100) + "content" + strings.Repeat("</div>", 100),
 
 		// Multiple newlines
 		"Line 1\n\n\n\n\nLine 2",

--- a/converter/markdown.go
+++ b/converter/markdown.go
@@ -66,6 +66,13 @@ var (
 	// Patterns for promoting a table's header row (see promoteTableHeaderRows).
 	tableBlockPattern = regexp.MustCompile(`(?is)<table>.*?</table>`)
 	tableRowPattern   = regexp.MustCompile(`(?is)<tr>.*?</tr>`)
+
+	// residualWrapperTagPattern matches opening/closing <div> and non-semantic
+	// HTML5 sectioning wrappers left by unhandled Confluence macros (issue #5).
+	// These carry no Markdown meaning, so the tags are removed while their inner
+	// content is kept. Tags the converter intentionally emits (<br>, <details>,
+	// <summary>, <img>) and table tags are deliberately excluded.
+	residualWrapperTagPattern = regexp.MustCompile(`(?i)</?(?:figcaption|figure|section|article|header|footer|aside|nav|div)(?:\s[^>]*)?>`)
 )
 
 // CheckPandoc verifies that pandoc is available (embedded or in PATH).
@@ -571,6 +578,13 @@ func postProcessMarkdown(md string) string {
 
 	// Remove any remaining span tags
 	md = regexp.MustCompile(`</?span[^>]*>`).ReplaceAllString(md, "")
+
+	// Strip residual HTML wrapper tags left by unhandled Confluence macros
+	// (issue #5): opening/closing <div> and non-semantic sectioning wrappers carry
+	// no Markdown meaning, so drop the tags but keep their inner content. This runs
+	// after every specific macro conversion above; intentionally emitted tags
+	// (<br>, <details>, <summary>, <img>, table tags) are excluded from the set.
+	md = residualWrapperTagPattern.ReplaceAllString(md, "")
 
 	// Clean up HTML entities using the shared map
 	for entity, char := range htmlEntityMap {

--- a/converter/markdown_test.go
+++ b/converter/markdown_test.go
@@ -1200,6 +1200,100 @@ func TestConvertHTMLToMarkdown_TableWithListCell(t *testing.T) {
 	}
 }
 
+// --- Issue #5: residual-HTML (unhandled macro) cleanup ---
+
+// Phase 1 (TDD): expected RED against the current code.
+
+func TestPostProcessMarkdown_StripsResidualMacroDiv(t *testing.T) {
+	// An unrecognized macro wrapper leaks its opening <div ...> today.
+	input := "Before\n\n<div class=\"conf-macro output-block\">\n\nInner text\n\n</div>\n\nAfter"
+
+	result := postProcessMarkdown(input)
+
+	if strings.Contains(result, "<div") {
+		t.Errorf("Expected residual <div> to be stripped, got: %s", result)
+	}
+	for _, want := range []string{"Before", "Inner text", "After"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("Expected %q preserved, got: %s", want, result)
+		}
+	}
+}
+
+func TestPostProcessMarkdown_StripsSectioningWrappers(t *testing.T) {
+	input := "<section class=\"x\">\n\nSection body\n\n</section>\n\n<figure>\n\nFig\n\n</figure>"
+
+	result := postProcessMarkdown(input)
+
+	for _, tag := range []string{"<section", "</section>", "<figure", "</figure>"} {
+		if strings.Contains(result, tag) {
+			t.Errorf("Expected %s to be stripped, got: %s", tag, result)
+		}
+	}
+	if !strings.Contains(result, "Section body") || !strings.Contains(result, "Fig") {
+		t.Errorf("Expected content preserved, got: %s", result)
+	}
+}
+
+func TestConvertHTMLToMarkdown_StripsMacroWrappers(t *testing.T) {
+	if err := CheckPandoc(); err != nil {
+		t.Skipf("Pandoc not installed, skipping test: %v", err)
+	}
+
+	html := `<html><body>
+<p>Intro.</p>
+<div class="conf-macro output-block" data-macro-name="change-history">
+<table><thead><tr><th>Version</th></tr></thead><tbody><tr><td>1.0</td></tr></tbody></table>
+</div>
+<div class="plugin_attachments_container"><div class="plugin_attachments_table_title">Attachments</div></div>
+<p>End.</p>
+</body></html>`
+
+	md, err := ConvertHTMLToMarkdown(html)
+	if err != nil {
+		t.Fatalf("ConvertHTMLToMarkdown failed: %v", err)
+	}
+
+	if strings.Contains(md, "<div") || strings.Contains(md, "<span") {
+		t.Errorf("Expected no residual div/span HTML, got: %s", md)
+	}
+	for _, want := range []string{"Intro.", "Version", "1.0", "Attachments", "End."} {
+		if !strings.Contains(md, want) {
+			t.Errorf("Expected %q to survive, got: %s", want, md)
+		}
+	}
+}
+
+// Phase 2/3 (TDD): preserve-set locks — must pass after the fix and never regress.
+
+func TestPostProcessMarkdown_PreservesIntentionalHTML(t *testing.T) {
+	input := "<details>\n<summary>More</summary>\n\nHidden\n\n</details>\n\n<img src=\"a.png\" alt=\"pic\">"
+
+	result := postProcessMarkdown(input)
+
+	for _, want := range []string{"<details>", "<summary>", "</summary>", "</details>"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("Expected %q preserved, got: %s", want, result)
+		}
+	}
+	if !strings.Contains(result, "a.png") {
+		t.Errorf("Expected image preserved, got: %s", result)
+	}
+}
+
+func TestPostProcessMarkdown_PreservesRawTableTags(t *testing.T) {
+	// A pandoc raw-HTML fallback table must not be shredded by the cleanup.
+	input := "<table>\n<tr><td>cell</td></tr>\n</table>"
+
+	result := postProcessMarkdown(input)
+
+	for _, want := range []string{"<table>", "<tr>", "<td>", "cell"} {
+		if !strings.Contains(result, want) {
+			t.Errorf("Expected %q preserved, got: %s", want, result)
+		}
+	}
+}
+
 func TestPostProcessMarkdown_AllEmojis(t *testing.T) {
 	// Test all text emoji shortcodes defined in the textEmojis map
 	tests := []struct {


### PR DESCRIPTION
## Summary

Closes #5 — converted Markdown was still leaving "blocks of HTML surrounded with Markdown" for unhandled Confluence macros (e.g. a Change History macro), forcing a second cleanup tool.

**Root cause:** unhandled macros are wrapped in `<div class="...">`. `postProcessMarkdown` already stripped all closing `</div>` and all `<span>` tags and converted a handful of *known* macro classes — but had **no general removal of residual *opening* `<div ...>` tags**, so unrecognized macro wrappers leaked.

**Fix:** a residual-HTML cleanup pass (after all specific macro conversions) that removes opening/closing `<div>` and non-semantic HTML5 sectioning wrappers (`section, article, header, footer, nav, aside, figure, figcaption`), **keeping inner content**. Tags the converter intentionally emits (`<br>`, `<details>`, `<summary>`, `<img>`) and table tags are excluded — so real content and raw-HTML fallback tables are preserved. No content is dropped (the reporter's accepted "convert to text" option).

### Before → After (representative macro doc)
```
<div class="conf-macro output-block">          ->  | Version | Author |
| Version | Author | ...                            |---------|--------|
<div class="plugin_attachments_container">          | 1.0     | Jane   |
Attachments                                         Attachments
```
Output now contains **zero** `<div>`/`<span>` tags; issue #6's `testpage.doc` converts identically (no regression).

## Testing (TDD, same rigor as #8)
- Strip tests written **first and confirmed failing**, then fixed.
- Preserve-set locks: `<details>`/`<summary>`, `<img>`, and raw fallback `<table>` tags survive.
- End-to-end `ConvertHTMLToMarkdown` on a macro-wrapped document (change-history table + unknown macro + attachments) → clean Markdown.
- Fuzz seeds added to both `FuzzPostProcessMarkdown` and `FuzzPreProcessHTML`; **active** fuzzing 45s each (≈204K + 590K execs) — no crashers.
- `go test ./... -race` green · `go vet` clean · `gofmt` clean on `markdown.go`/`markdown_test.go`.

## Notes / limitations
- Like the existing span/div cleanup, this pass is **not fenced-code-block aware**, so a literal `<div>` inside a ``` code sample is also stripped. Matches current behavior; a code-fence-aware cleanup is a possible follow-up.
- Dropping *entire* named macro bodies (vs. keeping their text) would need a real HTML parser (regex can't match nested `<div>` reliably) — out of scope.
- I don't have the reporter's exact export; happy to validate against a real sample. The general wrapper-strip resolves the described symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)